### PR TITLE
fix(service): use a single shot etcd client

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: hound-dog
-version: 2.5.1
-crystal: 0.35
+version: 2.5.2
+crystal: ~> 0.35
 license: MIT
 
 dependencies:
@@ -11,12 +11,15 @@ dependencies:
   habitat:
     github: luckyframework/habitat
 
-  rendezvous-hash:
-    github: caspiano/rendezvous-hash
-
   log_helper:
     github: spider-gazelle/log_helper
     version: ~> 1.0
+
+  rendezvous-hash:
+    github: caspiano/rendezvous-hash
+
+  retriable:
+    github: Sija/retriable.cr
 
   tasker:
     github: spider-gazelle/tasker
@@ -32,4 +35,4 @@ development_dependencies:
     github: crystal-ameba/ameba
 
 authors:
-  - Caspian Baska <caspian@place.technology>
+  - Caspian Baska <caspian@place.tech>

--- a/spec/discovery_spec.cr
+++ b/spec/discovery_spec.cr
@@ -57,7 +57,12 @@ module HoundDog
       spawn(same_thread: true) { discovery.register }
 
       sleep 0.2
+
       discovery.registration_channel.receive.should_not be_nil
+
+      unless discovery.own_node?("hello")
+        pp! discovery.nodes
+      end
 
       discovery.own_node?("hello").should be_true
       discovery.unregister

--- a/spec/discovery_spec.cr
+++ b/spec/discovery_spec.cr
@@ -7,7 +7,7 @@ module HoundDog
     namespace = HoundDog.settings.service_namespace
 
     Spec.before_each do
-      client.kv.delete_prefix namespace
+      Service.clear_namespace
     end
 
     it "accepts a callback" do
@@ -44,6 +44,8 @@ module HoundDog
     end
 
     it "#own_node?" do
+      Service.clear_namespace
+
       service = "api"
       node_name = "bub"
       node_uri = "http://127.0.0.1:4242"


### PR DESCRIPTION
`Service` no longer reuses a single client connection.

This is in lieu of reconnection logic for the shared etcd client.