### PR TITLE
feat(discovery): add callback for changes when unregistered

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: hound-dog
-version: 2.5.3
+version: 2.6.0
 crystal: ~> 0.35
 license: MIT
 


### PR DESCRIPTION
Adds a `on_change` callback argument to the initializer of `HoundDog::Discovery`.
This allows a user to register a callback when not registering itself as a service node.