### PR TITLE
chore(etcd): update etcd client

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,12 +1,12 @@
 name: hound-dog
-version: 2.6.0
+version: 2.6.1
 crystal: ~> 0.35
 license: MIT
 
 dependencies:
   etcd:
     github: place-labs/crystal-etcd
-    version: ~> 1.0
+    version: ~> 1.1
 
   habitat:
     github: luckyframework/habitat

--- a/spec/discovery_spec.cr
+++ b/spec/discovery_spec.cr
@@ -131,7 +131,7 @@ module HoundDog
       lease = client.lease.grant etcd_ttl
 
       key = "#{namespace}/#{service}/#{node0_name}"
-      client.kv.put(key, node0_uri, lease: lease[:id])
+      client.kv.put(key, node0_uri, lease: lease.id)
 
       discovery = Discovery.new(
         service: service,
@@ -163,19 +163,19 @@ module HoundDog
       )
 
       spawn(same_thread: true) { discovery.register }
-      sleep 0.2
+      sleep 15.milliseconds
       discovery.registration_channel.receive.should_not be_nil
 
       # Create a service
       lease = client.lease.grant etcd_ttl
       key = "#{namespace}/#{service}/#{new_node_name}"
 
-      client.kv.put(key, new_node_uri, lease: lease[:id])
+      client.kv.put(key, new_node_uri, lease: lease.id)
 
-      sleep 0.2
+      sleep 15.milliseconds
 
-      etcd_nodes = Service.nodes(service).sort_by { |s| s[:name] }
-      local_nodes = discovery.nodes.sort_by { |s| s[:name] }
+      etcd_nodes = Service.nodes(service).sort_by &.[:name]
+      local_nodes = discovery.nodes.sort_by &.[:name]
 
       # Local nodes should match remote notes after initialisation
       etcd_nodes.should eq local_nodes
@@ -193,14 +193,14 @@ module HoundDog
       # Create a service
       lease = client.lease.grant etcd_ttl
       key = "#{namespace}/#{service}/#{discovery.name}"
-      client.kv.put(key, discovery.uri.to_s, lease: lease[:id])
+      client.kv.put(key, discovery.uri.to_s, lease: lease.id)
 
       spawn(same_thread: true) { discovery.register }
-      sleep 0.2
+      sleep 15.milliseconds
       discovery.registration_channel.receive.should_not be_nil
 
-      etcd_nodes = Service.nodes(service).sort_by { |s| s[:name] }
-      local_nodes = discovery.nodes.sort_by { |s| s[:name] }
+      etcd_nodes = Service.nodes(service).sort_by &.[:name]
+      local_nodes = discovery.nodes.sort_by &.[:name]
 
       # Local nodes should match remote notes after initialisation
       etcd_nodes.should eq local_nodes

--- a/spec/service_spec.cr
+++ b/spec/service_spec.cr
@@ -20,10 +20,10 @@ module HoundDog
       key2, value2 = "service/engine/foo", "http://foot:42"
       key3, value3 = "service/engine/bar", "http://bath:42"
 
-      client.kv.put(key0, value0, lease: lease[:id])
-      client.kv.put(key1, value1, lease: lease[:id])
-      client.kv.put(key2, value2, lease: lease[:id])
-      client.kv.put(key3, value3, lease: lease[:id])
+      client.kv.put(key0, value0, lease: lease.id)
+      client.kv.put(key1, value1, lease: lease.id)
+      client.kv.put(key2, value2, lease: lease.id)
+      client.kv.put(key3, value3, lease: lease.id)
 
       Service.services.sort.should eq ["api", "engine"]
     end
@@ -35,9 +35,9 @@ module HoundDog
       key1, value1 = "service/api/bath", "http://bath:42"
       key2, value2 = "service/engine/foo", "http://foo:42"
 
-      client.kv.put(key0, value0, lease: lease[:id])
-      client.kv.put(key1, value1, lease: lease[:id])
-      client.kv.put(key2, value2, lease: lease[:id])
+      client.kv.put(key0, value0, lease: lease.id)
+      client.kv.put(key1, value1, lease: lease.id)
+      client.kv.put(key2, value2, lease: lease.id)
 
       expected = [
         {name: "bath", uri: URI.parse("http://bath:42")},


### PR DESCRIPTION
Update to etcd 1.1

There are errors when the TTL  root key is missing in keep alive requests (paging @dukeraphaelng)

```
2021-03-04T00:18:09.037387Z  ERROR - hound_dog.service: in keep_alive: JSON key not found: TTL (Exception)
  from /Users/caspian/.asdf/installs/crystal/0.36.1/src/json/pull_parser.cr:385:7 in 'initialize:__pull_for_json_serializable'
  from lib/etcd/src/etcd/model/base.cr:7:5 in 'new_from_json_pull_parser'
  from lib/etcd/src/etcd/model/lease.cr:11:3 in 'new'
  from /Users/caspian/.asdf/installs/crystal/0.36.1/src/json/from_json.cr:13:3 in 'from_json'
  from lib/etcd/src/etcd/lease.cr:19:5 in 'keep_alive'
  from src/hound-dog/service.cr:217:29 in '->'
  from /Users/caspian/.asdf/installs/crystal/0.36.1/src/primitives.cr:255:3 in 'run_compute'
  from lib/tasker/src/tasker/future.cr:16:5 in 'trigger'
  from lib/tasker/src/tasker/one_shot.cr:20:5 in 'trigger'
  from lib/tasker/src/tasker/task.cr:58:43 in '->'
  from /Users/caspian/.asdf/installs/crystal/0.36.1/src/primitives.cr:255:3 in '->'
  from /Users/caspian/.asdf/installs/crystal/0.36.1/src/primitives.cr:255:3 in 'run'
  from /Users/caspian/.asdf/installs/crystal/0.36.1/src/fiber.cr:92:34 in '->'

2021-03-04T00:18:09.037443Z   INFO - hound_dog.service: in keep_alive: stopped keep_alive
```