### PR TITLE
feat(service): use shared client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
 language: crystal
-
-env:
-  - TRAVIS_TEST=true
-
-services:
-  - docker
+services: docker
 
 before_install:
-  # Install ETCD
-  - docker run --net="host" -p "2379:2379" -p "2380:2380" -e ALLOW_NONE_AUTHENTICATION=yes -d bitnami/etcd:3.3.13
+  - docker run -p 2379:2379 -p 2380:2380 -e ALLOW_NONE_AUTHENTICATION=yes -d bitnami/etcd:3.4.15
 
 install:
-  - shards install
+  - shards install --ignore-crystal-version
 
 before_script:
   - sleep 5
 
 script:
-  - crystal spec
+  - crystal spec -v
   - crystal tool format --check
   - bin/ameba

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: hound-dog
-version: 2.6.1
-crystal: ~> 0.35
+version: 2.7.0
+crystal: ">= 0.35.0"
 license: MIT
 
 dependencies:

--- a/src/hound-dog.cr
+++ b/src/hound-dog.cr
@@ -11,6 +11,12 @@ module HoundDog
       port: HoundDog.settings.etcd_port,
     )
   end
+
+  # Yield etcd connection, closing after block returns
+  def self.etcd_client
+    client = etcd_client
+    yield client ensure client.close
+  end
 end
 
 require "./hound-dog/*"


### PR DESCRIPTION
- Use a shared etcd client with retries (and the option to not-retry)
- Closes one-off clients used in class methods.

Closes #7 