### PR TITLE
fix(service): retries to registration etcd calls

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,12 +1,14 @@
 name: hound-dog
-version: 2.8.0
+version: 2.8.1
 crystal: ">= 0.35.0"
 license: MIT
+authors:
+  - Caspian Baska <caspian@place.tech>
 
 dependencies:
   etcd:
     github: place-labs/crystal-etcd
-    version: ~> 1.1
+    version: ~> 1.2
 
   habitat:
     github: luckyframework/habitat
@@ -34,6 +36,3 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-
-authors:
-  - Caspian Baska <caspian@place.tech>

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: hound-dog
-version: 2.8.1
-crystal: ">= 0.35.0"
+version: 2.9.0
+crystal: ">= 0.35.1"
 license: MIT
 authors:
   - Caspian Baska <caspian@place.tech>

--- a/spec/discovery_spec.cr
+++ b/spec/discovery_spec.cr
@@ -37,6 +37,8 @@ module HoundDog
 
       node0 = put(client, namespace, service, "bub", "http://127.0.0.1:4242")
 
+      Fiber.yield
+
       change_chan.receive.first.should eq node0
 
       spawn(same_thread: true) do
@@ -45,13 +47,21 @@ module HoundDog
         end
       end
 
-      node1 = put(client, namespace, service, "tub", "http://127.0.0.1:4242")
+      Fiber.yield
+
+      node1 = discovery.node
 
       change_chan.receive.should eq [node0, node1]
       register_chan.receive.should eq [node0, node1]
 
+      node2 = put(client, namespace, service, "tub", "http://127.0.0.1:4242")
+
+      change_chan.receive.should eq [node0, node1, node2]
+      register_chan.receive.should eq [node0, node1, node2]
+
       discovery.unregister
-      discovery.nodes.should eq [node0, node1]
+      discovery.nodes.should eq [node0, node2]
+      change_chan.receive.should eq [node0, node2]
     end
 
     it "#own_node?" do

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -7,5 +7,5 @@ require "../src/hound-dog"
 require "../src/hound-dog/*"
 
 Spec.before_suite do
-  ::Log.setup "*", :debug
+  ::Log.setup "*", :trace
 end

--- a/src/hound-dog/service.cr
+++ b/src/hound-dog/service.cr
@@ -274,7 +274,7 @@ module HoundDog
           if elapsed > ttl.seconds
             # Attempt to renew if lease has expired
             Log.warn { "keep_alive: lost lease #{id} for #{node_key}" }
-            ttl = new_lease(ttl)
+            new_lease(ttl)
           else
             # Otherwise keep alive lease
             renewed_ttl = etcd &.lease.keep_alive(id)


### PR DESCRIPTION
Uses an etcd client with retries for leases.
Failures when setting a key under a lease are retried, or lead to the generation of a new lease.